### PR TITLE
added inclusive/exclusive argument

### DIFF
--- a/range.js
+++ b/range.js
@@ -1,27 +1,30 @@
-module.exports = function range(a, b) {
+module.exports = function range(a, b, isInclusive) {
+    function untilB(i, b) {
+        return isInclusive ? i<=b : i<b; 
+    }
     return { 
 	map: function map(func) {
 	    var arr = []
-	    for (var i=a; i<b; i++) {
+	    for (var i=a; untilB(i, b); i++) {
 		arr.push(func(i))
 	    }
 	    return arr;
 	},
 	toArray: function toArray() {
 	    var arr = [];
-	    for (var i=a; i<b; i++) {
+	    for (var i=a; untilB(i, b); i++) {
 		arr.push(i);
 	    }
 	    return arr;
 	},
 	forEach: function forEach(func) {
-	    for(var i=a; i<b; i++){
+	    for(var i=a; untilB(i, b); i++){
 		func(i);
 	    }
 	    return undefined;
 	},
 	forEachAsync: function forEachAsync(func) {
-	    for (var i=a; i<b; i++) {
+	    for (var i=a; untilB(i, b); i++) {
 		process.nextTick(func.bind(null, i))
 	    }
 	}


### PR DESCRIPTION
This allows you to include the terminator number if you want, e.g. `range(1, 5, true)` becomes `[1,2,3,4,5]`. It maintains current (exclusive) functionality when that argument is not given.
